### PR TITLE
retrieve serial from flash ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(uart_bridge PUBLIC
 target_link_libraries(uart_bridge
 	pico_multicore
 	pico_stdlib
+	hardware_flash
 	tinyusb_device)
 
 pico_add_extra_outputs(uart_bridge)

--- a/serial.h
+++ b/serial.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern char serial[17];

--- a/uart-bridge.c
+++ b/uart-bridge.c
@@ -10,6 +10,9 @@
 #include <pico/stdlib.h>
 #include <string.h>
 #include <tusb.h>
+#include <hardware/flash.h>
+
+#include "serial.h"
 
 #if !defined(MIN)
 #define MIN(a, b) ((a > b) ? b : a)
@@ -263,11 +266,22 @@ void init_uart_data(uint8_t itf) {
 			parity_usb2uart(ud->usb_lc.parity));
 }
 
+static inline void init_serial() {
+	uint8_t id[8];
+	flash_get_unique_id(id);
+	for (int i = 0; i < 8; ++i) {
+		sprintf(serial + 2 * i, "%X", id[i]);
+	}
+	serial[16] = '\0';
+}
+
 int main(void)
 {
 	int itf;
 
 	set_sys_clock_khz(250000, false);
+
+	init_serial();
 
 	for (itf = 0; itf < CFG_TUD_CDC; itf++)
 		init_uart_data(itf);

--- a/usb-descriptors.c
+++ b/usb-descriptors.c
@@ -11,6 +11,8 @@
 
 #include <tusb.h>
 
+#include "serial.h"
+
 #define DESC_STR_MAX 20
 
 #define USBD_VID 0x2E8A /* Raspberry Pi */
@@ -68,10 +70,12 @@ static const uint8_t usbd_desc_cfg[USBD_DESC_LEN] = {
 		USBD_CDC_IN_OUT_MAX_SIZE),
 };
 
-static const char *const usbd_desc_str[] = {
+char serial[17];
+
+static char *const usbd_desc_str[] = {
 	[USBD_STR_MANUF] = "Raspberry Pi",
 	[USBD_STR_PRODUCT] = "Pico",
-	[USBD_STR_SERIAL] = "000000000000",
+	[USBD_STR_SERIAL] = serial,
 	[USBD_STR_CDC] = "Board CDC",
 };
 


### PR DESCRIPTION
Currently the serial number "000000000000" is hard-coded.
This will lead to problems when two RPico uart bridges are attached to the same computer because their device node are ambiguous.
With this commit the unique 8 byte ID of the flash chip is used as serial number encoded as hex.
Thus two bridges can be safely attached to same computer by using /dev/serial/by-id/usb-Raspberry_Pi_Pico_... device nodes or appropriate udev rules.
