### PR TITLE
Update to allow for PICO_BOARD override to build for Pico 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,21 @@
-name: CI
+name: pico-uart-bridge
 
 on:
   - push
   - pull_request
 
 jobs:
-  CI:
+  build:
+    name: Build ${{ matrix.name }}
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - board: pico
+            name: Raspberry Pi Pico
+          - board: pico2
+            name: Raspberry Pi Pico 2
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
@@ -23,7 +32,7 @@ jobs:
       - name: 'Configure'
         run: |
           mkdir -p build
-          cmake -B build
+          cmake -B build -DPICO_BOARD=${{ matrix.board }}
 
       - name: 'Build'
         run: |
@@ -32,6 +41,6 @@ jobs:
       - name: 'Upload binary'
         uses: actions/upload-artifact@v4
         with:
-          name: pico-uart-bridge.uf2
+          name: ${{ matrix.board }}-uart-bridge.uf2
           path: build/uart_bridge.uf2
           retention-days: 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ include(pico-sdk/pico_sdk_init.cmake)
 
 project(pico_uart_bridge)
 
+if (NOT PICO_BOARD)
+	set(PICO_BOARD pico CACHE STRING "Target board")
+endif()
+
 pico_sdk_init()
 
 add_executable(uart_bridge uart-bridge.c usb-descriptors.c)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,23 @@ Raspberry Pi Pico Pinout
 | GPIO17 (Pin 22)        | UART0 RX |
 | GPIO4 (Pin 6)          | UART1 TX |
 | GPIO5 (Pin 7)          | UART1 RX |
+
+Build for Raspberry Pi Pico / Pico 2
+------------------------------------
+
+Prerequisites:
+- CMake
+- ARM GCC toolchain (e.g. `arm-none-eabi-gcc`)
+- Python 3
+
+Build steps:
+1. Initialize submodules if you haven't already:
+   - `git submodule update --init --recursive`
+2. Run the build script (defaults to Pico 1):
+   - `./build.sh`
+
+The `.uf2` output will be created at `build/uart_bridge.uf2`.
+
+Board override:
+- To build for Pico 2, set `PICO_BOARD`:
+  - `PICO_BOARD=pico2 ./build.sh`

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
 BASE_DIR="$(dirname ${BASH_SOURCE[0]})"
-BUILD_DIR=$BASE_DIR/build
+BUILD_BOARD=${PICO_BOARD:-"pico"}
+BUILD_DIR=$BASE_DIR/build/$BUILD_BOARD
 PICO_SDK_DIR=$BASE_DIR/pico-sdk
 
 main() {
-	if [ ! -d "$PICO_SDK_DIR/.git" ]; then
+	if [ ! -e "$PICO_SDK_DIR/.git" ]; then
 		git submodule sync --recursive
 		git submodule update --init --recursive
 	fi
 
-	cmake -B $BUILD_DIR -S $BASE_DIR
+	mkdir -p $BUILD_DIR
+	cmake -B $BUILD_DIR -S $BASE_DIR -DPICO_BOARD=$BUILD_BOARD
 	make -C $BUILD_DIR
 }
 


### PR DESCRIPTION
- Bump pico-sdk to 2.2.0 for Pico 2 support
- Default builds still target Pico 1; Pico 2 selectable via PICO_BOARD=pico2
- Update build script and README with board selection and UF2 output info